### PR TITLE
Rearrange page information: left is facts, right is why

### DIFF
--- a/left_column.md
+++ b/left_column.md
@@ -1,50 +1,46 @@
 
 
-### May 25-27 and June 2-4
+### May 25-27 and June 2-4, 9:00-12:15 CEST
 
 <a class="btn btn-info disabled" href="#" data-mode="1" target="_blank">Registration will open soon</a>
 
-We aim to take everyone who wants to attend this workshop, however our
-resources to provide interactive help is limited.  Thus,
+Please see information at right for registration options: learner or
+helper, and individual or as a team.
 
-- We accept as many Nordic participants as we can
-- *Everyone* may "bring your own breakout room": 4-5 learners and one
-  helper.  The helper is responsible for guiding the learners through
-  the exercises.
-
-For more details, see information at right.
-
-### Contact
-
-support@coderefinery.org
-
-
-### Format
-
-Hands-on informal and interactive online event with type-along type of
-presentations, live coding and demos. Short tutorials alternate with practical
-exercises.
-
-Online workshop, three half-days a week for two weeks, covering the full
-range of CodeRefinery lessons.
+Because of our Nordic funding, priority is for Nordic participants.
+This is the first Mega-CodeRefinery, so we reserve the right to make
+changes.
 
 
 
-### Course goals
+### Course goals and format
 
-The aim of this course is to demonstrate to and familiarize the workshop
-participants with best practices and tools for version control in modern
-research software development. The main focus is on using Git for efficiently
-writing and maintaining research software.
+In this course, you will become familiar with tools and best practices
+for version control in modern research software development. The main
+focus is on using Git for efficiently writing and maintaining research
+software.  We don't teach programming, but we teach the tools you need
+to use programming well.
+
+This is an informal and interactive online event with type-along type
+of presentations, live coding, and demos. Short tutorials alternate
+with practical exercises.
 
 
-### **Software requirements**
 
-Please follow the links below and make sure that you install all the required software packages
-([why we ask you to do this](https://coderefinery.github.io/installation/#why-are-we-asking-participants-to-install-software)).
+### Software requirements
+
+You need to install some software *before* CodeRefinery ([why we ask
+you to do
+this](https://coderefinery.github.io/installation/#why-are-we-asking-participants-to-install-software)).
+Please do this - *and check it* - in advance, otherwise you'll start off
+behind.
+
 Note that, e.g., a working Python executable on your laptop is not sufficient -
 a version greater than 3.4 is strongly recommended and a number of extra
-packages need to be installed as detailed on the Python installation page.
+packages need to be installed as detailed on the Python installation
+page.  **You also need to check your git configuration.**  **If you
+have an institutional laptop with limited rights, start in advance
+and/or ask for help to translate these instructions to work on your system.**
 
 - [Bash](https://coderefinery.github.io/installation/bash/)
 - [Editor](https://coderefinery.github.io/installation/editors/)
@@ -55,18 +51,22 @@ packages need to be installed as detailed on the Python installation page.
 - [Jupyter and JupyterLab](https://coderefinery.github.io/installation/jupyter)
 - [Snakemake](https://coderefinery.github.io/installation/snakemake)
 
-**You should try to do this on your on, but then you must verify your
-setup before the workshop: a) If you are part of a team (see
-right), your helper should check your setup  b) Otherwise, join one of
-the "setup check" sessions below.**
+**You should either a) drop by one of our verification sessions in
+advance, or b) verify with your team's helper before the workshop.**
 
 
 ### Schedule
 
 The schedule includes frequent breaks.  All times are in Central
-European Summer Time.
+European Summer Time.  [Convert 9:00 CEST to your time zone](https://arewemeetingyet.com/Stockholm/2020-05-25/09:00/CodeRefinery%20online#eyJ1cmwiOiJodHRwczovL2NvZGVyZWZpbmVyeS5naXRodWIuaW8vMjAyMC0wNS0yNS1vbmxpbmUvIn0=).
 
-25 May (M)
+The schedule is subject to change.
+
+Pre-workshop installation help and verification times (see above)
+- 21.may (Th) 13-14 CEST
+- 22.may (F)  13-14 CEST
+
+**25 May (M)**
 - 9:00 - 9:30
   [Welcome and practical information](https://github.com/coderefinery/workshop-intro/blob/master/README.md)
   (TBA)
@@ -75,8 +75,7 @@ European Summer Time.
   (TBA)
 
 
-26 May (T)
-
+**26 May (T)**
 - 9:00 - 11:30
   [Introduction to version control - part 2/2](https://coderefinery.github.io/git-intro/)
   (TBA)
@@ -85,14 +84,14 @@ European Summer Time.
   (TBA)
 
 
-27 May (W)
+**27 May (W)**
 - 9:00 - 12:00
   [Collaborative distributed version control 2/2](https://coderefinery.github.io/git-collaborative/)
   (TBA)
 
 
 
-2 June (T)
+**2 June (T)**
 - 9:00 - 10:30
   [Modular code development](https://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/modular-code-development/master/talk.md)
   (TBA)
@@ -101,7 +100,7 @@ European Summer Time.
   (TBA)
 
 
-3 June (W)
+**3 June (W)**
 - 9:00 - 10:30
   [Documentation](https://coderefinery.github.io/documentation/)
   (TBA)
@@ -110,7 +109,7 @@ European Summer Time.
   (TBA)
 
 
-4 June (Th)
+**4 June (Th)**
 - 9:00 - 10:00
   [Automated testing part 1/2](https://coderefinery.github.io/testing/)
   (TBA)
@@ -123,3 +122,20 @@ European Summer Time.
 - 11:45 - 12:00
   [Concluding remarks and where to go from here](https://github.com/coderefinery/workshop-outro/blob/master/README.md)
   (TBA)
+
+
+### Location
+
+The workshop will be held online, participant links will be sent to
+registered participants.
+
+
+### Price
+
+Free of charge, funded by the [Nordic e-Infrastructure
+Collaboration](https://neic.no/).
+
+
+### Contact
+
+support@coderefinery.org

--- a/right_column.md
+++ b/right_column.md
@@ -1,19 +1,4 @@
 
-
-### Location and time
-
-The workshop will be held online, details later.  We aim to make this
-workshop accessible to as many people as possible.
-
-[Convert 9:00 to my time zone](https://arewemeetingyet.com/Stockholm/2020-05-25/09:00/CodeRefinery%20online#eyJ1cmwiOiJodHRwczovL2NvZGVyZWZpbmVyeS5naXRodWIuaW8vMjAyMC0wNS0yNS1vbmxpbmUvIn0=)
-
-
-
-### Price
-
-Free of charge.
-
-
 ### Who the course is for
 
 Are you doing any of these things below:
@@ -21,12 +6,46 @@ Are you doing any of these things below:
 - You change scripts written by your colleagues.
 - You write code that is used in research by you or others.
 
-If yes, then this course is for you.  Most participants are not
+If yes, then this course is for you.  This is not designed for
 "professional code developers" or computer scientists.
 
 If you develop research code and you know all the tools
 already, join us as a helper! It's fun, and you always learn
 something new about a subject by teaching it.
+
+
+### Mega-CodeRefinery?
+
+Welcome to the *first* online mega-CodeRefinery.  This is "mega"
+because in the past we have always been limited by physical space or
+number of helpers.  *We are now taking direct action to reach as many
+people as possible, but this also means we are trying something new.*
+We are introducing the concept of **teams** to "bring your own breakout
+rooms" to accept as many people as possible.
+
+
+### How to join
+
+We are normally limited by number of helpers, thus:
+
+- Anyone may register as a learner, we will try to take as many as we can.
+- Or you can register as a helper.  If you are somewhat comfortable
+  with these tools, you can be a helper! (see below)
+- Register as a team, one helper and 4-6 learners.
+  - We will accept all complete teams
+  - This is a great opportunity to bring your friends and colleagues
+    and prepare for the future together.
+  - Decide some team name, and when registering, everone enter this
+    same name so that we can link you together.
+  - During the exercise sessions in breakout rooms, the helper has
+    primary responsibility for their group's hands-on exercises.
+    Still, instructors drop by to check and help
+    as needed, so don't worry if you don't know everything.
+
+If you've been to a CodeRefinery before and have used git some after
+that, you are definitely capable of being a helper.  If you routinely
+use git and know Python somewhat well, you are also very qualified to
+be a helper.
 
 
 ### What we will not teach
@@ -37,26 +56,6 @@ language that you use in your work and research.  We try to keep the course as
 language-independent as possible but we will show some basic code examples in
 Python.
 
-### How to join
-
-Welcome to the first online mega-CodeRefinery.  This is "mega" because
-historically, we have been limited by physical space or number of
-helpers.  We want take direct action to reach as many people as possible.
-
-We are normally limited by number of helpers, thus:
-
-- Anyone may register as a learner, we will try to take as many as we can.
-- Or you can register as a helper
-- Register as a team, one helper and 4-5 learners.
-  - We will accept all complete teams
-  - This is a great opportunity to bring your friends and colleagues
-    and prepare for the future together.
-  - Decide some team name, and when registering, everone enter this
-    same name so that we can link you together.
-  - During the exercise sessions in breakout rooms, the helper has
-    primary responsibility for their group's hands-on exercises.
-    Instructors provide advance training and drop by to check and help
-    as needed.
 
 
 ### Prerequisites
@@ -68,10 +67,9 @@ We are normally limited by number of helpers, thus:
   contains the essentials.
 - Basics in one or more programming languages.
 - You will need to bring a laptop.
-- If this is an in-person workshop, it is good if you have access to Eduroam.
 - You need to install some software. Please follow links in the schedule.
 - It is useful if you have a basic idea of how Git works. We will start from
-  the basics, but please go through
+  the basics anyway, but please go through
   [this Git-refresher material](https://coderefinery.github.io/git-refresher/)
   for a basic overview and important configuration steps.
 

--- a/title.md
+++ b/title.md
@@ -1,5 +1,5 @@
-# CodeRefinery Online, May-June 2020
+# CodeRefinery, May 25 - June 4, 2020
 
-### Subtitle
+### Mega-, Online CodeRefinery to reach everyone
 
 ---


### PR DESCRIPTION
- Left column focuses on facts of the workshop, with most important
  stuff at the top.
- Right is the whys and hows.
- Most important information goes to the tops always.  Also try to
  de-duplicate.
- There are also some other checks.
- For review: please sanity check that this makes sense and it's a
  good arrangement.  What else can be simplified.  Especially, how can
  we make the concept of teams and how they are registered more clear?